### PR TITLE
New feature onClose added

### DIFF
--- a/svyIdle/idle/idle.js
+++ b/svyIdle/idle/idle.js
@@ -35,6 +35,19 @@ angular.module('svyIdle',['servoy'])
 				recurIdleCall: recurIdleCall,
 				idle: idle
 			})
+		},
+		/**
+		 * Setup trigger on closing NG Desktop window
+		 *
+		 * @param {function} onClose triggers when window is closed by user
+		 */
+		onClose: function(onClose) {
+			$(document).idle({
+				onClose: function() {
+					if(onClose)
+						$window.executeInlineScript(onClose.formname, onClose.script, []);
+				}
+			})
 		}
 
 	}

--- a/svyIdle/idle/idle.spec
+++ b/svyIdle/idle/idle.spec
@@ -55,6 +55,16 @@
 					"type":"boolean"
 				}
 			]
+		},
+		"onClose": 
+	   	{
+	    	"parameters":
+	    	[		    	
+				{
+					"name":"onClose",
+					"type":"function"
+				}
+			]
 		}
  	}
 }

--- a/svyIdle/idle/jquery.idle.js
+++ b/svyIdle/idle/jquery.idle.js
@@ -38,6 +38,7 @@
         onActive: function () {}, //callback function to be executed after back from idleness
         onHide: function () {}, //callback function to be executed when window is hidden
         onShow: function () {}, //callback function to be executed when window is visible
+        onClose: function () {},//callback function to be executed when window is closed
         keepTracking: true, //set it to false if you want to track only the first time
         startAtIdle: false,
         recurIdleCall: false
@@ -94,6 +95,11 @@
               settings.onShow.call();
             }
           }
+        });
+      }
+      if (settings.onClose){
+        $(window).on('beforeunload', function(e){
+        settings.onClose.call();
         });
       }
     });


### PR DESCRIPTION
Added onClose method to create trigger at instant when window is closed. This is useful in case when we need to execute some code  at the instant when user has closed window. We have added onClose as separate api so that it can be set if needed i.e. no change to current idle plugin method calls.

Co-Authored-By: KhurramKiani <68713560+KhurramKiani@users.noreply.github.com>